### PR TITLE
feat: use deburr from lodash-es

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import deburr from 'lodash.deburr';
+import {deburr} from 'lodash-es';
 import escapeStringRegexp from 'escape-string-regexp';
 import builtinReplacements from './replacements.js';
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 	],
 	"dependencies": {
 		"escape-string-regexp": "^5.0.0",
-		"lodash.deburr": "^4.1.0"
+		"lodash-es": "^4.17.21"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
This should resolve the following error in a project of mine: `The requested module '/_nuxt/node_modules/.pnpm/lodash.deburr@4.1.0/node_modules/lodash.deburr/index.js?v=6396a93e' does not provide an export named 'default'`.